### PR TITLE
Port song id extension to chrome

### DIFF
--- a/background/inject.js
+++ b/background/inject.js
@@ -1,7 +1,9 @@
-browser.browserAction.onClicked.addListener( () => {
+const ext = (typeof browser !== 'undefined') ? browser : (typeof chrome !== 'undefined' ? chrome : {});
+
+ext.browserAction.onClicked.addListener( () => {
 	// Basically injects into the attention-bar iframes too.
 	// Guess this is not great, but it's not life-threatening either..
-	browser.tabs.executeScript({
+    ext.tabs.executeScript({
 		file: "/dist/index.js",
 		allFrames: true
 	})

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,9 @@
   "description": "Music recognition. Like shazam or soundhound.",
   "homepage_url": "https://github.com/losnappas/Song-identifier",
   "icons": {
-    "16": "icons/icon.svg",
-    "48": "icons/icon.svg",
-    "96": "icons/icon.svg"
+    "16": "icons/icon.png",
+    "48": "icons/icon.png",
+    "96": "icons/icon.png"
   },
 
   "applications": {
@@ -19,19 +19,19 @@
   },
 
   "background": {
-	  "scripts": ["/background/inject.js"]
+	  "scripts": ["background/inject.js"]
   },
 
 
   "browser_action": {
 	  "browser_style": true,
 	  "default_title": "Identify",
-	  "default_icon": "icons/icon.svg"
+	  "default_icon": "icons/icon.png"
   },
 
   "permissions": [
     "activeTab",
-    "*://*.acrcloud.com/v1/identify",
+    "https://*.acrcloud.com/*",
     "storage"
   ],
   "options_ui": {

--- a/options/options.js
+++ b/options/options.js
@@ -1,9 +1,11 @@
+const ext = (typeof browser !== 'undefined') ? browser : (typeof chrome !== 'undefined' ? chrome : {});
+
 function save(e) {
 	// uhh whatever
 	let v = len.value
 	v = v > 15 ? 15 : v
 	// local vs sync probs no big deal in performance - hoping it is cached somewhere.
-	browser.storage.sync.set({
+	ext.storage && ext.storage.sync && ext.storage.sync.set && ext.storage.sync.set({
 		len: v,
 		host: host.value,
 		key: key.value,
@@ -13,7 +15,7 @@ function save(e) {
 
 
 function restore() {
-	browser.storage.sync.get()
+	(ext.storage && ext.storage.sync && ext.storage.sync.get ? ext.storage.sync.get() : Promise.resolve({}))
 	.then(values => {
 		len.value = values.len || ''
 		host.value = values.host || ''

--- a/songid-react/src/Identifier.js
+++ b/songid-react/src/Identifier.js
@@ -5,6 +5,7 @@ import axios from 'axios';
 import crypto from 'crypto';
 import qs from 'querystring';
 import styled from 'styled-components';
+import ext from './webext';
 
 async function getArrayBuffer(blob) {
 	if ('function' === typeof blob.arrayBuffer) {
@@ -25,7 +26,7 @@ async function getArrayBuffer(blob) {
 	}
 }
 
-const gettingStoredSecrets = browser.storage.sync.get();
+const gettingStoredSecrets = (ext.storage && ext.storage.sync && ext.storage.sync.get) ? ext.storage.sync.get() : Promise.resolve({});
 
 function create_sign(data, secret_key) {
 	return crypto.createHmac('sha1', secret_key).update(data).digest().toString('base64');

--- a/songid-react/src/Recording.js
+++ b/songid-react/src/Recording.js
@@ -3,6 +3,7 @@ import usePromise from 'react-promise';
 import Countdown from 'react-countdown';
 import styled from 'styled-components';
 import Identifier from './Identifier';
+import ext from './webext';
 
 const BlueLink = styled.a`
 	color: lightblue;
@@ -58,7 +59,7 @@ export default ({ rec, goAgain }) => {
 					<GoAgainButton
 						type="button"
 						onClick={async () => {
-							const settings = await browser.storage.sync.get();
+                            const settings = ext.storage && ext.storage.sync && ext.storage.sync.get ? await ext.storage.sync.get() : {};
 							const t = settings.len || 8;
 							setTime(t);
 							const pp = goAgain(t);

--- a/songid-react/src/webext.js
+++ b/songid-react/src/webext.js
@@ -1,0 +1,49 @@
+// Minimal cross-browser wrapper with Promise-based storage APIs
+const raw = (typeof browser !== 'undefined') ? browser : (typeof chrome !== 'undefined' ? chrome : {});
+
+const storage = raw && raw.storage && raw.storage.sync ? {
+    sync: {
+        get: (keys) => new Promise((resolve, reject) => {
+            try {
+                if (raw.storage.sync.get.length >= 1) {
+                    // Chrome-style callback API
+                    raw.storage.sync.get(keys || null, (items) => {
+                        const err = raw.runtime && raw.runtime.lastError;
+                        if (err) reject(err);
+                        else resolve(items || {});
+                    });
+                } else {
+                    // Firefox-style promise API
+                    raw.storage.sync.get(keys || null).then(resolve, reject);
+                }
+            } catch (e) {
+                resolve({});
+            }
+        }),
+        set: (items) => new Promise((resolve, reject) => {
+            try {
+                if (raw.storage.sync.set.length >= 1) {
+                    // Chrome-style callback API
+                    raw.storage.sync.set(items, () => {
+                        const err = raw.runtime && raw.runtime.lastError;
+                        if (err) reject(err);
+                        else resolve();
+                    });
+                } else {
+                    // Firefox-style promise API
+                    raw.storage.sync.set(items).then(resolve, reject);
+                }
+            } catch (e) {
+                resolve();
+            }
+        })
+    }
+} : null;
+
+const ext = { ...raw };
+if (storage) {
+    ext.storage = storage;
+}
+
+export default ext;
+


### PR DESCRIPTION
Port Song ID extension to Chrome by adding a compatibility layer and updating the manifest.

The original extension was built for Firefox, using `browser.*` APIs and `.svg` icons. This PR introduces a `webext.js` wrapper to abstract `browser` and `chrome` APIs, particularly for `storage.sync`, and updates the manifest and relevant scripts to ensure functionality on the Chrome platform.

---
<a href="https://cursor.com/background-agent?bcId=bc-318c9574-52a3-4a41-ada8-6dc75491c525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-318c9574-52a3-4a41-ada8-6dc75491c525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

